### PR TITLE
Fix event payloads on scraper failure

### DIFF
--- a/packages/scraper/src/scraper/scraper.dto.ts
+++ b/packages/scraper/src/scraper/scraper.dto.ts
@@ -18,6 +18,7 @@ export class ScraperResultDto {
   jobId: string;
   data: unknown;
   method: 'htmlExtractor' | 'apiExtractor' | 'fileExtractor';
+  error?: string;
 }
 
 export enum C_KEYS {

--- a/packages/scraper/src/scraper/scraper.service.ts
+++ b/packages/scraper/src/scraper/scraper.service.ts
@@ -88,6 +88,24 @@ export class ScraperService {
         result = await this.runExtractionPipeline(page, payload);
       }
 
+      if (!result) {
+        const errorMessage = 'No extraction method succeeded';
+        await this.cacheManager.set<ScraperCachedLinkDto>(
+          `${C_KEYS.LINK}:${payload.url}`,
+          {
+            status: 'failed',
+          },
+        );
+        const failPayload: ScraperResultDto = {
+          jobId: payload.jobId,
+          method: 'fileExtractor',
+          data: [],
+          error: errorMessage,
+        };
+        this.backendPageQueue.emit('page.failed', failPayload);
+        return failPayload;
+      }
+
       await this.cacheManager.set<ScraperCachedLinkDto>(
         `${C_KEYS.LINK}:${payload.url}`,
         {
@@ -111,9 +129,15 @@ export class ScraperService {
       );
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      this.backendPageQueue.emit('page.failed', errorMessage);
+      const failPayload: ScraperResultDto = {
+        jobId: payload.jobId,
+        method: 'fileExtractor',
+        data: [],
+        error: errorMessage,
+      };
+      this.backendPageQueue.emit('page.failed', failPayload);
 
-      return errorMessage;
+      return failPayload;
     }
   }
 


### PR DESCRIPTION
## Summary
- extend `ScraperResultDto` with optional `error`
- send structured `page.failed` events from scraper and emit failures when no extractor works

## Testing
- `yarn lint` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861758df6d08322914c56013b452ade